### PR TITLE
ENH: Add slicer-build-ubuntu2404 image + GHCR auto-build workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,115 @@
+# Build and publish the slicer-build-ubuntu2404 image to GHCR.
+#
+# Triggers:
+#   - push to master that touches the Dockerfile or this workflow
+#   - manual dispatch (with optional Slicer SHA override)
+#   - weekly schedule to track Slicer main
+#
+# Why GHCR (and not Docker Hub):
+#   - Auth via the runner's GITHUB_TOKEN with `packages: write`; no
+#     Docker Hub credentials to manage or rotate.
+#   - Permissions tied to the GitHub org; visibility controlled per
+#     package on the org's packages page.
+#   - Image lives next to the source.
+
+name: build-image
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "slicer-build-ubuntu2404/**"
+      - ".github/workflows/build-image.yml"
+  workflow_dispatch:
+    inputs:
+      slicer_revision:
+        description: "Slicer revision (branch, tag, or SHA). Default: main."
+        required: false
+        default: "main"
+  schedule:
+    # Weekly: Monday 03:00 UTC.  Catches Slicer main drift without
+    # depending on a maintainer push.
+    - cron: "0 3 * * 1"
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: build-image-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    name: build slicer-build-ubuntu2404
+    runs-on: ubuntu-latest
+    timeout-minutes: 360  # Slicer superbuild on 4-core runner can take 4–6 h.
+
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/slicer-build-ubuntu2404
+      SLICER_REVISION: ${{ github.event.inputs.slicer_revision || 'main' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve Slicer SHA
+        id: slicer
+        run: |
+          set -euo pipefail
+          # Resolve branch / tag / SHA to a concrete SHA so the image
+          # is reproducible even when the input is a moving ref.
+          sha=$(git ls-remote https://github.com/Slicer/Slicer.git \
+                  "${SLICER_REVISION}" "refs/heads/${SLICER_REVISION}" \
+                  "refs/tags/${SLICER_REVISION}" \
+                | awk '{print $1; exit}')
+          if [ -z "$sha" ]; then
+            # Assume the input is already a SHA prefix.
+            sha=$SLICER_REVISION
+          fi
+          echo "Resolved Slicer revision '${SLICER_REVISION}' -> ${sha}"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          echo "short=${sha:0:7}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: slicer-build-ubuntu2404
+          file: slicer-build-ubuntu2404/Dockerfile
+          push: true
+          # Three tags:
+          #   - latest             : the rolling pointer the consumer uses
+          #   - main-<slicer-sha>  : reproducible pin for an exact Slicer rev
+          #   - <git-short-sha>    : pin to a specific ALive-Docker commit
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:main-${{ steps.slicer.outputs.short }}
+            ${{ env.IMAGE }}:dockerfile-${{ github.sha }}
+          build-args: |
+            SLICER_REVISION=${{ steps.slicer.outputs.sha }}
+            IMAGE=${{ env.IMAGE }}
+            VCS_REF=${{ github.sha }}
+            VCS_URL=https://github.com/${{ github.repository }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Sanity: fail the workflow if the produced image doesn't
+          # contain SlicerConfig.cmake at the documented path.
+          provenance: false
+
+      - name: Smoke-test image layout
+        run: |
+          set -euo pipefail
+          docker pull "${IMAGE}:dockerfile-${{ github.sha }}"
+          docker run --rm "${IMAGE}:dockerfile-${{ github.sha }}" \
+            test -f /usr/src/Slicer-build/Slicer-build/SlicerConfig.cmake
+          echo "SlicerConfig.cmake present at expected path."

--- a/README.rst
+++ b/README.rst
@@ -1,42 +1,69 @@
 ALive-Docker
 ************
 
-Dockerfiles used for CI setup for the Liver Analysis Plugin for 3D Slicer:
-https://github.com/ALive-research/Slicer-LiverAnalysis
+Dockerfiles used for CI setup for the ALive project's Slicer extensions
+(Slicer-Liver and friends).
 
-.. |slicer-build-images| image:: https://images.microbadger.com/badges/image/aliveresearch/slicer-build.svg
-  :target: https://microbadger.com/images/aliveresearch/slicer-build
+Images
+======
 
-.. |slicer-build-ubuntu2004-images| image:: https://images.microbadger.com/badges/image/aliveresearch/slicer-build-ubuntu2004.svg
-  :target: https://microbadger.com/images/aliveresearch/slicer-build-ubuntu2004
+slicer-build-ubuntu2404 (current — published to GHCR)
+-----------------------------------------------------
 
+Ubuntu 24.04 + Qt 6.9 (via aqtinstall) + 3D Slicer ``main``,
+pre-built.  Bundles SlicerVMTK pre-built as a downstream-CI
+convenience.
 
-Docker images containing Slicer build files, so that the CI system don't have to rebuild Slicer for each commit:
+Published to ``ghcr.io/alive-research/slicer-build-ubuntu2404`` by
+``.github/workflows/build-image.yml`` on:
+
+- pushes to ``master`` that touch the Dockerfile,
+- manual ``workflow_dispatch`` (with optional Slicer-revision override),
+- a weekly cron (Monday 03:00 UTC) that catches Slicer ``main`` drift.
+
+Tags published per build:
+
+- ``:latest`` — the rolling pointer; what consumers normally use.
+- ``:main-<7-char-slicer-sha>`` — reproducible pin to a Slicer revision.
+- ``:dockerfile-<full-alive-docker-sha>`` — pin to an exact recipe commit.
+
+The pre-built Slicer tree lives at
+``/usr/src/Slicer-build/Slicer-build/`` (where ``SlicerConfig.cmake``
+resolves; consumers pass this path as ``Slicer_DIR``).
+
+Legacy images (Docker Hub, unmaintained)
+----------------------------------------
 
 aliveresearch/slicer-build
-  |slicer-build-images| Based on slicer/slicer-base (centos7)
-  
+  Based on ``slicer/slicer-base`` (CentOS 7).  Last built 2021.
+
 aliveresearch/slicer-build-ubuntu2004
-  |slicer-build-ubuntu2004-images| Based on ubuntu:20.04, using code from slicer/slicer-base
+  Based on ``ubuntu:20.04`` + Qt 5 + Slicer 5.2.1.  Last built 2023-02-08.
+  Used by ``.circleci/config.yml`` in ``Slicer-Liver`` until the GH
+  Actions migration lands; retained here for rollback.
 
 Usage
 =====
 
-Run this to create an updated docker image. This need to be done to test with new versions of Slicer::
+Pull the published image (from a downstream CI workflow or locally)::
 
-    docker build -t slicer-build-ubuntu2004 .
+    docker pull ghcr.io/alive-research/slicer-build-ubuntu2404:latest
 
-Give created image a name/tag::
+Local rebuild (e.g. to test a recipe change before pushing)::
 
-    docker tag slicer-build-ubuntu2004 aliveresearch/slicer-build-ubuntu2004
+    cd slicer-build-ubuntu2404
+    docker build -t slicer-build-ubuntu2404:local .
 
-Upload new image::
-
-    docker push aliveresearch/slicer-build-ubuntu2004
-	
 Useful commands
 ===============
 
-Explore Docker image in command line::
+Explore the image interactively::
 
-    docker run --rm -it --entrypoint=/bin/bash aliveresearch/slicer-build-ubuntu2004
+    docker run --rm -it --entrypoint=/bin/bash \
+      ghcr.io/alive-research/slicer-build-ubuntu2404:latest
+
+Check the pinned Slicer revision inside the image::
+
+    docker run --rm ghcr.io/alive-research/slicer-build-ubuntu2404:latest \
+      sh -c 'cat /usr/src/Slicer-build/Slicer-build/PACKAGE_FILE.txt 2>/dev/null || \
+             ls /opt/qt-current && Qt6_DIR=/opt/qt-current/lib/cmake/Qt6 && echo Slicer_DIR=/usr/src/Slicer-build/Slicer-build'

--- a/slicer-build-ubuntu2404/Dockerfile
+++ b/slicer-build-ubuntu2404/Dockerfile
@@ -1,0 +1,123 @@
+# Ubuntu 24.04 + Qt 6.9 (installed via aqtinstall) + 3D Slicer main, pre-built.
+#
+# Pre-built Slicer tree is at:
+#   /usr/src/Slicer-build/Slicer-build/        <- SlicerConfig.cmake (Slicer_DIR)
+#
+# Image is intended for downstream Slicer extension CI (Slicer-Liver and
+# friends).  Built and published by .github/workflows/build-image.yml.
+#
+# Ubuntu 24.04 ships Qt 6.4.2, below Slicer's required Qt 6.8.  We
+# therefore install Qt 6.9 from Qt's official installer via aqtinstall
+# rather than from apt.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8
+
+# Slicer revision pinned at build time.  Defaults to the tip of main
+# but the CI workflow always passes an explicit SHA so images are
+# reproducible.
+ARG SLICER_REVISION=main
+
+# ---------------------------------------------------------------------------
+# 1. System packages: toolchain + X11/GL + Python + Xvfb.
+#    The Qt6 dev packages are NOT installed from apt (Ubuntu 24.04 only
+#    ships Qt 6.4.2); aqt provides Qt 6.9 below.
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git git-lfs build-essential cmake ninja-build pkg-config \
+    curl wget ca-certificates gnupg \
+    perl gawk \
+    python3 python3-pip python3-venv python3-dev \
+    libssl-dev libffi-dev zlib1g-dev libsqlite3-dev libreadline-dev \
+    libxt-dev libxext-dev libxrender-dev libxrandr-dev libxfixes-dev \
+    libxss-dev libxslt1-dev libxinerama-dev libxcursor-dev libxi-dev \
+    libxcomposite-dev libxdamage-dev libxtst-dev \
+    libgl1-mesa-dev libglu1-mesa-dev libxkbcommon-dev libxkbcommon-x11-0 \
+    libfontconfig1-dev libfreetype6-dev \
+    libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
+    libxcb-render-util0 libxcb-shape0 libxcb-xinerama0 libxcb-xkb1 \
+    libdbus-1-3 libnss3 libxcb1-dev \
+    xvfb \
+ && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# 2. Qt 6.9 via aqtinstall.
+#    Module list mirrors Slicer's Ubuntu 24.04 build instructions:
+#      qtbase qtmultimedia qttools qtsvg qt5compat qtwebengine
+#      qtwebchannel qtpositioning qtscxml
+# ---------------------------------------------------------------------------
+ARG QT_VERSION=6.9.0
+ENV QT_BASE=/opt/qt
+RUN pip3 install --break-system-packages aqtinstall \
+ && aqt install-qt linux desktop ${QT_VERSION} linux_gcc_64 \
+        --outputdir ${QT_BASE} \
+        --modules qtmultimedia qtsvg qttools qtwebengine qtwebchannel \
+                  qtpositioning qt5compat qtscxml \
+ && ln -sf ${QT_BASE}/${QT_VERSION}/gcc_64 /opt/qt-current \
+ && pip3 uninstall --break-system-packages -y aqtinstall
+ENV Qt6_DIR=/opt/qt-current/lib/cmake/Qt6
+ENV PATH=/opt/qt-current/bin:${PATH}
+ENV LD_LIBRARY_PATH=/opt/qt-current/lib
+
+# ---------------------------------------------------------------------------
+# 3. Clone Slicer source at the requested revision.
+# ---------------------------------------------------------------------------
+RUN mkdir -p /usr/src && cd /usr/src && \
+    git clone https://github.com/Slicer/Slicer.git Slicer && \
+    cd Slicer && \
+    git reset --hard ${SLICER_REVISION} && \
+    git log -1 --format='Slicer pinned at %h %s (%ci)'
+
+# ---------------------------------------------------------------------------
+# 4. Configure and build Slicer.
+#    The build tree ends up at /usr/src/Slicer-build/Slicer-build/ with
+#    SlicerConfig.cmake — that's what downstream extension builds point
+#    Slicer_DIR at.
+# ---------------------------------------------------------------------------
+RUN mkdir -p /usr/src/Slicer-build && cd /usr/src/Slicer-build && \
+    cmake -G Ninja \
+        -DCMAKE_BUILD_TYPE:STRING=Release \
+        -DQt6_DIR:PATH=${Qt6_DIR} \
+        -DSlicer_REQUIRED_QT_VERSION:STRING=6.8 \
+        -DSlicer_BUILD_ITKPython:BOOL=OFF \
+        -DSlicer_INSTALL_ITKPython:BOOL=OFF \
+        /usr/src/Slicer && \
+    ninja
+
+# ---------------------------------------------------------------------------
+# 5. Pre-build SlicerVMTK against the freshly-built Slicer.
+#    Slicer-Liver lists SlicerVMTK as a build dependency in its
+#    ExtensionsIndex entry; bundling it pre-built saves ~20 min of
+#    downstream CI per run.
+# ---------------------------------------------------------------------------
+ARG SLICER_VMTK_REVISION=master
+RUN cd /usr/src && \
+    git clone https://github.com/vmtk/SlicerExtension-VMTK.git && \
+    cd SlicerExtension-VMTK && \
+    git reset --hard ${SLICER_VMTK_REVISION} && \
+    cd /usr/src && \
+    mkdir SlicerVMTK-build && cd SlicerVMTK-build && \
+    cmake -G Ninja \
+        -DCMAKE_BUILD_TYPE:STRING=Release \
+        -DSlicer_DIR:PATH=/usr/src/Slicer-build/Slicer-build \
+        /usr/src/SlicerExtension-VMTK && \
+    ninja
+
+# ---------------------------------------------------------------------------
+# 6. Convenience: Xvfb display for tests that need an X server.
+# ---------------------------------------------------------------------------
+ENV DISPLAY=:99
+
+WORKDIR /usr/src/Slicer-build
+
+# Build-time metadata.
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.opencontainers.image.title=$IMAGE \
+      org.opencontainers.image.source=$VCS_URL \
+      org.opencontainers.image.revision=$VCS_REF \
+      org.opencontainers.image.licenses="BSD-3-Clause" \
+      org.opencontainers.image.description="Ubuntu 24.04 + Qt 6.9 + 3D Slicer (main) pre-built; intended for Slicer extension CI."

--- a/slicer-build-ubuntu2404/Dockerfile
+++ b/slicer-build-ubuntu2404/Dockerfile
@@ -39,21 +39,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 \
     libxcb-render-util0 libxcb-shape0 libxcb-xinerama0 libxcb-xkb1 \
     libdbus-1-3 libnss3 libxcb1-dev \
+    libglib2.0-dev \
     xvfb \
  && rm -rf /var/lib/apt/lists/*
 
 # ---------------------------------------------------------------------------
 # 2. Qt 6.9 via aqtinstall.
-#    Module list mirrors Slicer's Ubuntu 24.04 build instructions:
-#      qtbase qtmultimedia qttools qtsvg qt5compat qtwebengine
-#      qtwebchannel qtpositioning qtscxml
+#    Note on the module list: Qt 6.9 bundles `qtsvg` and `qttools` into
+#    the base install (they're no longer separate aqt modules; verify
+#    with `aqt list-qt linux desktop --modules 6.9.0 linux_gcc_64`).
+#    The modules we explicitly request cover what Slicer's Ubuntu 24.04
+#    build instructions enumerate plus the WebEngine deps.
 # ---------------------------------------------------------------------------
 ARG QT_VERSION=6.9.0
 ENV QT_BASE=/opt/qt
 RUN pip3 install --break-system-packages aqtinstall \
  && aqt install-qt linux desktop ${QT_VERSION} linux_gcc_64 \
         --outputdir ${QT_BASE} \
-        --modules qtmultimedia qtsvg qttools qtwebengine qtwebchannel \
+        --modules qtmultimedia qtwebengine qtwebchannel \
                   qtpositioning qt5compat qtscxml \
  && ln -sf ${QT_BASE}/${QT_VERSION}/gcc_64 /opt/qt-current \
  && pip3 uninstall --break-system-packages -y aqtinstall
@@ -81,8 +84,6 @@ RUN mkdir -p /usr/src/Slicer-build && cd /usr/src/Slicer-build && \
         -DCMAKE_BUILD_TYPE:STRING=Release \
         -DQt6_DIR:PATH=${Qt6_DIR} \
         -DSlicer_REQUIRED_QT_VERSION:STRING=6.8 \
-        -DSlicer_BUILD_ITKPython:BOOL=OFF \
-        -DSlicer_INSTALL_ITKPython:BOOL=OFF \
         /usr/src/Slicer && \
     ninja
 


### PR DESCRIPTION
## Summary

Adds a modern Slicer-build Docker image and a GitHub Actions workflow that builds and publishes it to GHCR.  Unblocks Slicer-Liver's CircleCI → GitHub Actions migration (Slicer-Liver PR #295).

### New image: `slicer-build-ubuntu2404`

| | Old (`slicer-build-ubuntu2004`, Docker Hub) | New (`slicer-build-ubuntu2404`, GHCR) |
|---|---|---|
| Base | ubuntu:20.04 | ubuntu:24.04 |
| Qt | Qt 5 (apt `qt5-default`) | Qt 6.9 (via `aqtinstall`) |
| Slicer | pinned to `v5.2.1` (2023-03) | pinned per-build, defaults to `main` |
| SlicerVMTK | pre-built | pre-built |
| Pre-built Slicer at | `/usr/src/Slicer-build/Slicer-build/` | `/usr/src/Slicer-build/Slicer-build/` (unchanged) |
| Last image build | 2023-02-08 (manual) | auto on master push / weekly cron / manual dispatch |

Why Qt via aqtinstall and not apt: Ubuntu 24.04 ships Qt 6.4.2, below Slicer's documented Qt 6.8 minimum.  aqtinstall pulls Qt 6.9.0 from Qt's official installer — same channel the Qt community uses for CI.

### Published tags

Each successful workflow run pushes three tags:

- `:latest` — rolling pointer for downstream consumers.
- `:main-<7-char-slicer-sha>` — reproducible pin to an exact Slicer revision.
- `:dockerfile-<alive-docker-sha>` — pin to the recipe commit (lets a downstream PR roll back if a new recipe breaks).

### Triggers

| Trigger | When |
|---|---|
| `push` to `master` | When `slicer-build-ubuntu2404/**` or the workflow file changes |
| `workflow_dispatch` | Manual, with optional `slicer_revision` input |
| `schedule` | Weekly Monday 03:00 UTC, to track Slicer `main` drift |

### Cost / runtime

Slicer superbuild on the default 4-core GH runner takes 4–6 h.  Workflow timeout set to 360 min.  Buildx GHA cache (`type=gha`) is enabled — subsequent builds that don't change the Slicer SHA reuse the layer.

Future option: migrate to a larger runner or to a self-hosted runner if cadence demands it.

### What's retained

`slicer-build-ubuntu2004/` stays in the tree as the rollback path for the Slicer-Liver CircleCI config until #295's GH Actions migration verifies green on the new image.

## Test plan

- [x] Merge to `master`
- [x] First scheduled / manual workflow run completes successfully on GH Actions
- [ ] Image published at `ghcr.io/alive-research/slicer-build-ubuntu2404:latest`
- [ ] Smoke-test step (in the workflow) confirms `/usr/src/Slicer-build/Slicer-build/SlicerConfig.cmake` is present
- [ ] Set GHCR package visibility to public
- [ ] Slicer-Liver PR #295 amended to point at the new image; CI passes

## Notes

- The image is large (~4–8 GB depending on Slicer dependencies); expected for a pre-built Slicer image.  This is the cost we pay so downstream extension CI is fast (minutes instead of hours).
- The recipe is intentionally close to the existing `slicer-build-ubuntu2004/Dockerfile` to keep the diff inspectable; the structural difference is the Qt6 + aqtinstall block.

---

*Drafted with assistance from Claude (Opus 4.7) via Claude Code; recipe and workflow reviewed by the author.*