### PR TITLE
FIX: Hard-code lowercase owner in GHCR image name

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -46,7 +46,11 @@ jobs:
     timeout-minutes: 360  # Slicer superbuild on 4-core runner can take 4–6 h.
 
     env:
-      IMAGE: ghcr.io/${{ github.repository_owner }}/slicer-build-ubuntu2404
+      # GHCR (and Docker generally) requires lowercase repository names.
+      # `${{ github.repository_owner }}` resolves to `ALive-research`
+      # (mixed case), which buildx rejects.  Hard-code the lowercase
+      # owner so the image name is stable and explicit.
+      IMAGE: ghcr.io/alive-research/slicer-build-ubuntu2404
       SLICER_REVISION: ${{ github.event.inputs.slicer_revision || 'main' }}
 
     steps:


### PR DESCRIPTION
## Summary

`${{ github.repository_owner }}` resolves to `ALive-research` (mixed case), which GHCR / Docker reject:

```
ERROR: failed to build: invalid tag "ghcr.io/ALive-research/slicer-build-ubuntu2404:latest": repository name must be lowercase
```

Hard-coding `alive-research` (lowercase) in the workflow's `IMAGE` env var.

Caught on the first post-merge run of #2 (5-second failure before any actual build started).

## Test plan

- [x] Merge to `master`
- [ ] Auto-triggered workflow run reaches the build step (will then take 4–6 h for the actual Slicer build)
- [ ] Image published at `ghcr.io/alive-research/slicer-build-ubuntu2404:latest`