### PR TITLE
FIX: Unblock first green build — drop VMTK pre-build, free runner disk

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -54,6 +54,22 @@ jobs:
       SLICER_REVISION: ${{ github.event.inputs.slicer_revision || 'main' }}
 
     steps:
+      # ubuntu-latest runners ship with only ~14 GB free; the Slicer
+      # SuperBuild generates 25–30+ GB of intermediate artifacts.
+      # Drop pre-installed cruft (Android SDK, .NET, Haskell, etc.) to
+      # free ~25 GB before `docker build`.  Without this the build trips
+      # on "No space left on device" partway through Slicer's deps.
+      - name: Free runner disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false  # too slow; not on our critical path
+          swap-storage: false    # keep swap, the build may need it
+          docker-images: true
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,7 @@ slicer-build-ubuntu2404 (current — published to GHCR)
 -----------------------------------------------------
 
 Ubuntu 24.04 + Qt 6.9 (via aqtinstall) + 3D Slicer ``main``,
-pre-built.  Bundles SlicerVMTK pre-built as a downstream-CI
-convenience.
+pre-built.
 
 Published to ``ghcr.io/alive-research/slicer-build-ubuntu2404`` by
 ``.github/workflows/build-image.yml`` on:

--- a/slicer-build-ubuntu2404/Dockerfile
+++ b/slicer-build-ubuntu2404/Dockerfile
@@ -88,26 +88,7 @@ RUN mkdir -p /usr/src/Slicer-build && cd /usr/src/Slicer-build && \
     ninja
 
 # ---------------------------------------------------------------------------
-# 5. Pre-build SlicerVMTK against the freshly-built Slicer.
-#    Slicer-Liver lists SlicerVMTK as a build dependency in its
-#    ExtensionsIndex entry; bundling it pre-built saves ~20 min of
-#    downstream CI per run.
-# ---------------------------------------------------------------------------
-ARG SLICER_VMTK_REVISION=master
-RUN cd /usr/src && \
-    git clone https://github.com/vmtk/SlicerExtension-VMTK.git && \
-    cd SlicerExtension-VMTK && \
-    git reset --hard ${SLICER_VMTK_REVISION} && \
-    cd /usr/src && \
-    mkdir SlicerVMTK-build && cd SlicerVMTK-build && \
-    cmake -G Ninja \
-        -DCMAKE_BUILD_TYPE:STRING=Release \
-        -DSlicer_DIR:PATH=/usr/src/Slicer-build/Slicer-build \
-        /usr/src/SlicerExtension-VMTK && \
-    ninja
-
-# ---------------------------------------------------------------------------
-# 6. Convenience: Xvfb display for tests that need an X server.
+# 5. Convenience: Xvfb display for tests that need an X server.
 # ---------------------------------------------------------------------------
 ENV DISPLAY=:99
 


### PR DESCRIPTION
## Summary

After #2 + #3 merged, the first auto-triggered `build-image` run got **3 hours** into Slicer's SuperBuild and then failed at the very last step — the SlicerVMTK pre-build:

```
Could not find a package configuration file provided by "ExtraMarkups"
```

Two coordinated fixes here to unblock the first end-to-end green image.

### Fix 1: drop the SlicerVMTK pre-build (`d38a177`) — required

SlicerExtension-VMTK now depends on the `ExtraMarkups` Slicer extension. Bundling VMTK without also bundling ExtraMarkups (and any further transitive Slicer-extension deps) gives a half-built dep chain that fails CMake configure.

Short-term: **drop VMTK from the image**. Downstream Slicer-Liver CI builds VMTK + ExtraMarkups + SegmentEditorExtraEffects itself (~20–30 min added per CI run). Trade-off: simpler image now, vs. fast CI later.

Follow-up (separate PR): bundle the full Slicer-Liver dep chain (VMTK + ExtraMarkups + SegmentEditorExtraEffects + transitive deps) once we have a known-good baseline image to layer on top of.

### Fix 2: free ~25 GB of runner disk space (`73a57ca`) — defensive

ubuntu-latest runners ship with ~14 GB free; Slicer SuperBuild generates 25–30+ GB of intermediate artifacts. The first run *happened* to fit, but the margin is uncomfortably thin. `jlumbroso/free-disk-space` reclaims ~25 GB by dropping the pre-installed Android SDK, .NET, Haskell, and runner tool cache before `docker build`.

Not strictly required, but cheap insurance against the next time someone adds a step that needs more disk.

## Why this should be fast (not another 3 hours)

GHA buildx cache (`cache-from: type=gha`, set in #2) captured the layer up to and including the successful Slicer build. The next build should resume from that cache and only re-do the post-Slicer steps (which now is just Xvfb env + labels + push). Expected runtime: **5–15 min**, not 3 hours.

## Test plan

- [x] Merge
- [ ] Auto-triggered workflow completes successfully
- [ ] Image published at `ghcr.io/alive-research/slicer-build-ubuntu2404:latest`
- [ ] Smoke-test step (in the workflow) confirms `/usr/src/Slicer-build/Slicer-build/SlicerConfig.cmake` is present
- [ ] Make the GHCR package public (org → Packages → settings)
- [ ] Push Slicer-Liver's pre-committed migration commit (local on `refactor/adr-0005-github-actions-ci`)

---

*Drafted with assistance from Claude (Opus 4.7) via Claude Code.*