### PR TITLE
ENH: install python3-pytest in slicer-build-ubuntu2404

### DIFF
--- a/slicer-build-ubuntu2404/Dockerfile
+++ b/slicer-build-ubuntu2404/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git git-lfs build-essential cmake ninja-build pkg-config \
     curl wget ca-certificates gnupg \
     perl gawk \
-    python3 python3-pip python3-venv python3-dev \
+    python3 python3-pip python3-venv python3-dev python3-pytest \
     libssl-dev libffi-dev zlib1g-dev libsqlite3-dev libreadline-dev \
     libxt-dev libxext-dev libxrender-dev libxrandr-dev libxfixes-dev \
     libxss-dev libxslt1-dev libxinerama-dev libxcursor-dev libxi-dev \


### PR DESCRIPTION
## Summary
- Add `python3-pytest` to the apt install list in `slicer-build-ubuntu2404/Dockerfile`

## Why
Downstream extension CI (Slicer-Liver et al.) now ships pytest-based tests per [ADR-0008 testing strategy](https://github.com/ALive-research/Slicer-Liver/blob/preview/Docs/adr/0008-testing-strategy.md). Slicer-Liver PR [#316](https://github.com/ALive-research/Slicer-Liver/pull/316) adds a `conftest.py` scaffold with `--render-interactive` and registers two CTest entries (`pytest_scaffold` + `pytest_scaffold_render_interactive`). Those entries currently skip at configure time when pytest is absent — so the tests never run on CI.

## Why apt rather than pip
The image already does `pip3 install --break-system-packages aqtinstall` to work around PEP 668, then uninstalls aqtinstall after Qt is in place. Apt-packaging pytest keeps the Python tree system-managed and avoids a second `--break-system-packages` invocation. The Ubuntu 24.04 packaged version is sufficient for the v2.0.0 use case — only standard pytest API is exercised (`pytest_addoption`, fixtures, parametrize, no third-party plugins).

## Impact on image size
Marginal — pytest pulls a handful of small Python packages (pluggy, iniconfig, etc.) on top of the Python already in the image.

## Test plan
- [ ] Image builds cleanly on the GHCR auto-build workflow
- [ ] `docker run ghcr.io/alive-research/slicer-build-ubuntu2404:latest pytest --version` reports the pytest version
- [ ] Slicer-Liver PR #316's CTest entries `pytest_scaffold` and `pytest_scaffold_render_interactive` discover pytest and run (rather than skip at configure time)

## UX impact
N/A — non-UI change (build infrastructure).

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. Opened for human review before merge.*