### PR TITLE
ENH: install python3-jsonschema in slicer-build-ubuntu2404

### DIFF
--- a/slicer-build-ubuntu2404/Dockerfile
+++ b/slicer-build-ubuntu2404/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git git-lfs build-essential cmake ninja-build pkg-config \
     curl wget ca-certificates gnupg \
     perl gawk \
-    python3 python3-pip python3-venv python3-dev python3-pytest \
+    python3 python3-pip python3-venv python3-dev \
+    python3-pytest python3-jsonschema \
     libssl-dev libffi-dev zlib1g-dev libsqlite3-dev libreadline-dev \
     libxt-dev libxext-dev libxrender-dev libxrandr-dev libxfixes-dev \
     libxss-dev libxslt1-dev libxinerama-dev libxcursor-dev libxi-dev \

--- a/slicer-build-ubuntu2404/Dockerfile
+++ b/slicer-build-ubuntu2404/Dockerfile
@@ -30,7 +30,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl wget ca-certificates gnupg \
     perl gawk \
     python3 python3-pip python3-venv python3-dev \
-    python3-pytest python3-jsonschema \
     libssl-dev libffi-dev zlib1g-dev libsqlite3-dev libreadline-dev \
     libxt-dev libxext-dev libxrender-dev libxrandr-dev libxfixes-dev \
     libxss-dev libxslt1-dev libxinerama-dev libxcursor-dev libxi-dev \
@@ -110,7 +109,25 @@ RUN mkdir -p /usr/src/Slicer-build && cd /usr/src/Slicer-build && \
     ninja
 
 # ---------------------------------------------------------------------------
-# 5. Convenience: Xvfb display for tests that need an X server.
+# 5. Test/runtime tooling for downstream extension CI.
+#
+#    These packages are NOT used by Slicer's own build.  Installing them
+#    in their own RUN layer AFTER the cmake+ninja step means future
+#    additions or removals here do not invalidate the ~3-hour Slicer
+#    build layer cache.
+#
+#    Anything Slicer-Liver (or other downstream) test/CI needs but
+#    Slicer's build does not should land in this layer:
+#      - python3-pytest      — Slicer-Liver pytest scaffold (ADR-0008)
+#      - python3-jsonschema  — terminology JSON schema validation (PR #315)
+# ---------------------------------------------------------------------------
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-pytest \
+    python3-jsonschema \
+ && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# 6. Convenience: Xvfb display for tests that need an X server.
 # ---------------------------------------------------------------------------
 ENV DISPLAY=:99
 


### PR DESCRIPTION
## Summary
- Add `python3-jsonschema` to the image
- Restructure the Dockerfile so test-only Python tooling (`pytest`, `jsonschema`) lives in a new RUN layer AFTER the `cmake + ninja` Slicer build, not in the first apt-install layer upstream of it
- Move `python3-pytest` (added in PR #6) into the new test-tooling layer

## Why now
Slicer-Liver PR [#315](https://github.com/ALive-research/Slicer-Liver/pull/315) adds `Testing/Python/unit/test_terminology_assets.py` which uses the `jsonschema` package to validate the SCT terminology JSON against the dcmqi `segment-context-schema`. Without it in the image, the assertion skips via `pytest.importorskip` rather than running as a real CI regression.

## Why the restructure
Slicer's `cmake + ninja` build is ~3 hours. Before this PR, all apt packages — including test-only tooling like pytest — lived in the first RUN layer, upstream of the Slicer-build layer. That meant every future test-tool addition (or removal) invalidated the Slicer-build cache and forced a full rebuild on the GHCR auto-build workflow. PR #6 (pytest) already triggered one such rebuild; landing #7 unchanged would have triggered another.

Splitting test-runtime tooling into its own post-Slicer-build RUN means future additions reuse the cached Slicer build — minutes instead of hours.

**One-time cost**: this restructure invalidates the Slicer-build layer once (because the build-deps apt list changes when `python3-pytest` moves out). After it lands, the cached Slicer build is stable across test-tooling changes.

## Commits
1. `5f8c561` — add `python3-jsonschema` to the build-time apt list (original PR draft).
2. `04f4b53` — restructure: move `python3-pytest` and `python3-jsonschema` out of the build-deps apt list and into a new RUN layer after the `cmake + ninja` step.

Squash-merge collapses these into a single commit reflecting the final structure; or keep both for the narrative.

## Test plan
- [ ] Image builds cleanly on the GHCR auto-build workflow (one full rebuild expected this time)
- [ ] `docker run …slicer-build-ubuntu2404:latest python3 -c "import pytest, jsonschema; print(pytest.__version__, jsonschema.__version__)"` reports versions
- [ ] On a subsequent change that only touches the new test-tooling RUN, the Slicer-build layer is cached (verify in the GHCR build log)
- [ ] Slicer-Liver PR #315's `test_main_terminology_validates_against_dcmqi_schema` runs (rather than skips) on CI

## UX impact
N/A — non-UI change (build infrastructure).

## Future use of this layer
Anything Slicer-Liver (or other downstream extensions) needs in the test/CI environment but Slicer's own build does NOT need belongs in the new test-tooling RUN — e.g. additional pytest plugins, mock libraries, future schema validators, lint tooling for tests.

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. Layer-caching restructure suggested by the human reviewer and applied by the orchestrating Opus 4.7 session. Opened for human review before merge.*