### PR TITLE
ENH: install pytest + jsonschema into Slicer's embedded Python (PythonSlicer)

### DIFF
--- a/slicer-build-ubuntu2404/Dockerfile
+++ b/slicer-build-ubuntu2404/Dockerfile
@@ -116,15 +116,35 @@ RUN mkdir -p /usr/src/Slicer-build && cd /usr/src/Slicer-build && \
 #    additions or removals here do not invalidate the ~3-hour Slicer
 #    build layer cache.
 #
-#    Anything Slicer-Liver (or other downstream) test/CI needs but
-#    Slicer's build does not should land in this layer:
-#      - python3-pytest      — Slicer-Liver pytest scaffold (ADR-0008)
-#      - python3-jsonschema  — terminology JSON schema validation (PR #315)
+#    Slicer ships an embedded Python tree at
+#    /usr/src/Slicer-build/python-install/.  Slicer extension builds
+#    set CMake's Python3_EXECUTABLE to its launcher (PythonSlicer), so
+#    test scaffolds that probe Python3_EXECUTABLE — like Slicer-Liver's
+#    pytest scaffold from PR #316, which runs ``import slicer`` inside
+#    pytest — only see packages installed *inside* that embedded tree.
+#    System-level python3-pytest from apt does not show up there.
+#
+#    Strategy:
+#      - apt-installed python3-pytest / python3-jsonschema sit in the
+#        system Python for developer-side scripts and apt-managed
+#        convenience.
+#      - The same two packages are *also* installed into Slicer's
+#        embedded Python via ``PythonSlicer -m pip`` so extension test
+#        scaffolds find them.
 # ---------------------------------------------------------------------------
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pytest \
     python3-jsonschema \
  && rm -rf /var/lib/apt/lists/*
+
+# Install the same tooling into Slicer's embedded Python.  Extension
+# CMake scaffolds probe Python3_EXECUTABLE which resolves to
+# PythonSlicer for downstream builds; system-Python pytest is invisible
+# from there.
+RUN /usr/src/Slicer-build/python-install/bin/PythonSlicer \
+        -m pip install --no-cache-dir \
+        pytest \
+        jsonschema
 
 # ---------------------------------------------------------------------------
 # 6. Convenience: Xvfb display for tests that need an X server.


### PR DESCRIPTION
## Summary
Install `pytest` and `jsonschema` into Slicer's embedded Python tree (`/usr/src/Slicer-build/python-install/`, accessed via `PythonSlicer`), in addition to the apt-installed system-Python versions from PR #6 / #7.

## Why
Slicer's CMake macros set `Python3_EXECUTABLE` to `PythonSlicer` for downstream extension builds. Test scaffolds that probe `Python3_EXECUTABLE` — like Slicer-Liver PR [#316](https://github.com/ALive-research/Slicer-Liver/pull/316), which needs `import slicer` to work inside pytest — only see packages installed *inside* that embedded tree. System-Python `python3-pytest` from apt is invisible to it.

### Observed failure
Slicer-Liver PR #316's CI on this image reported at the CMake configure step:
```
-- Slicer-Liver: pytest not importable from /usr/src/Slicer-build/python-install/bin/PythonSlicer;
   skipping pytest scaffold registration.
```
The `pytest_scaffold` and `pytest_scaffold_render_interactive` CTest entries from #316 were never registered, and the new pytest test surface (including Slicer-Liver PR #315's terminology load test) never ran on CI.

## Strategy
Keep the apt installs from PR #6 / #7 — they're useful for developer-side scripts and apt-managed convenience. **Also** install the same packages into Slicer's embedded Python via `PythonSlicer -m pip install`, so the extension test scaffold finds them.

## Layer placement
Same post-Slicer-build layer as the apt installs from PR #7. The 3-hour Slicer-build cache is preserved.

## Image-size cost
~10 MB for the duplicate `pytest` install in Slicer's embedded Python. Acceptable.

## Test plan
- [ ] Image builds cleanly on the GHCR auto-build workflow
- [ ] `docker run …slicer-build-ubuntu2404:latest /usr/src/Slicer-build/python-install/bin/PythonSlicer -c "import pytest, jsonschema; print(pytest.__version__, jsonschema.__version__)"` reports versions
- [ ] Slicer-Liver PR #316's CMake configure step now registers `pytest_scaffold` (no "pytest not importable" warning)
- [ ] Slicer-Liver PR #316's `pytest_scaffold` and `pytest_scaffold_render_interactive` CTest entries actually run

## UX impact
N/A — non-UI change (build infrastructure).

## Cross-refs
- ALive-Docker PR #6 (system-Python pytest) — merged
- ALive-Docker PR #7 (system-Python jsonschema + layer restructure) — merged
- Slicer-Liver PR #316 (the pytest scaffold that needs this)
- Slicer-Liver PR #315 (the terminology test that runs once #316 + this PR are in place)

---

*AI-assisted authorship: this pull request was drafted with help from Anthropic's Claude (Opus 4.7, `claude-opus-4-7`) via Claude Code. The failure was diagnosed from PR #316's CI log; root cause identified as system-Python vs embedded-Slicer-Python separation. Opened for human review before merge.*